### PR TITLE
Allow you to create multiple URI mappings with the same assets bundle.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,10 @@
 # Configurable Assets Bundle for Dropwizard
 
-This GitHub repository contains a drop-in replacement for Yammer's `AssetsBundle` class that allows for a better
-developer experience.  Developers can use the `ConfiguredAssetsBundle` class anywhere they would use a `AssetsBundle`
-in their Dropwizard applications and take advantage of the ability to specify redirects for URIs to that loads them from
-disk instead of the classpath.  This allows developers to edit browser-interpreted files and reload them without needing
-to recompile source.
+This GitHub repository contains a drop-in replacement for Yammer's `AssetsBundle` class that allows
+for a better developer experience.  Developers can use the `ConfiguredAssetsBundle` class anywhere
+they would use a `AssetsBundle` in their Dropwizard applications and take advantage of the ability
+to specify redirects for URIs to that loads them from disk instead of the classpath.  This allows
+developers to edit browser-interpreted files and reload them without needing to recompile source.
 
 [![Build Status](https://travis-ci.org/dropwizard-bundles/dropwizard-configurable-assets-bundle.png)](https://travis-ci.org/dropwizard-bundles/dropwizard-configurable-assets-bundle)
 
@@ -35,7 +35,7 @@ public class SampleConfiguration extends Configuration implements AssetsBundleCo
 }
 ```
 
-Add the redirect bundle:
+Add the assets bundle:
 ```java
 public class SampleService extends Application<SampleConfiguration> {
     public static void main(String[] args) throws Exception {
@@ -59,8 +59,6 @@ A sample local development config:
 assets:
   overrides:
     /dashboard: src/main/resources/assets/
-  mimeTypes:
-    woff: application/font-woff
 ```
 
 You can override multiple external folders with a single configuration in a following way:
@@ -69,4 +67,51 @@ assets:
   overrides:
     /dashboard/assets: /some/absolute/path/with/assets/
     /dashboard/images: /some/different/absolute/path/with/images
+```
+
+## Add Mime Types
+
+Dropwizard 0.8 allows you to add new mimetypes directly to the application context.
+
+```java
+public class SampleService extends Application<SampleConfiguration> {
+   ...
+
+   @Override
+   public void run(SampleConfiguration configuration, Environment environment) {
+       environment
+           .getApplicationContext()
+           .getMimeTypes()
+           .addMimeMapping("mp4", "video/mp4");
+   }
+}
+```
+
+However if you want to override a pre-existing mime type, or add them dynamically, you can do so
+with your assets configuration.
+
+```yml
+assets:
+  mimeTypes:
+    woff: application/font-woff
+```
+
+## Multiple URI Mappings
+
+You can map different folders to multiple top-level directories if you wish.
+
+```java
+public class SampleService extends Application<SampleConfiguration> {
+    ...
+
+    @Override
+    public void initialize(Bootstrap<SampleConfiguration> bootstrap) {
+        bootstrap.addBundle(new ConfiguredAssetsBundle(
+            ImmutableMap.<String, String>builder()
+                .put("/assets/", "/dashboard/")
+                .put("/data/", "/static-data/")
+                .build()
+        ));
+    }
+}
 ```

--- a/src/test/java/io/dropwizard/bundles/assets/AssetServletTest.java
+++ b/src/test/java/io/dropwizard/bundles/assets/AssetServletTest.java
@@ -11,6 +11,7 @@ import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.http.MimeTypes;
+import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.servlet.ServletTester;
 import org.junit.After;
 import org.junit.Before;
@@ -30,8 +31,11 @@ public class AssetServletTest {
   private static final String NOINDEX_SERVLET = "/noindex_servlet/";
   private static final String NOCHARSET_SERVLET = "/nocharset_servlet/";
   private static final String MIME_SERVLET = "/mime_servlet/";
+  private static final String MM_ASSET_SERVLET = "/mm_assets/";
+  private static final String MM_JSON_SERVLET = "/mm_json/";
   private static final String ROOT_SERVLET = "/";
   private static final String RESOURCE_PATH = "/assets";
+  private static final String JSON_RESOURCE_PATH = "/json";
 
   // ServletTester expects to be able to instantiate the servlet with zero arguments
   private static Iterable<Map.Entry<String, String>> resourceMapping(String resourcePath,
@@ -83,16 +87,35 @@ public class AssetServletTest {
     public MimeMappingsServlet() {
       super(resourceMapping(RESOURCE_PATH, MIME_SERVLET), null, DEFAULT_CHARSET, DEFAULT_CACHE_SPEC,
               EMPTY_OVERRIDES, EMPTY_MIMETYPES);
-      setDefaultCharset(null);
       Map<String, String> mimeMappings = new HashMap<String, String>();
       mimeMappings.put("bar", "application/bar");
       setMimeTypes(mimeMappings.entrySet());
     }
   }
 
+  public static class MultipleMappingsServlet extends AssetServlet {
+    public MultipleMappingsServlet() {
+      super(ImmutableMap.<String, String>builder()
+                      .put(RESOURCE_PATH, MM_ASSET_SERVLET)
+                      .put(JSON_RESOURCE_PATH, MM_JSON_SERVLET)
+                      .build().entrySet(),
+              null, DEFAULT_CHARSET, DEFAULT_CACHE_SPEC, EMPTY_OVERRIDES, EMPTY_MIMETYPES
+      );
+    }
+  }
+
   private final ServletTester servletTester = new ServletTester();
   private final HttpTester.Request request = HttpTester.newRequest();
   private HttpTester.Response response;
+
+  private HttpTester.Response makeRequest(String uri) throws Exception {
+    request.setURI(uri);
+    return makeRequest();
+  }
+
+  private HttpTester.Response makeRequest() throws Exception {
+    return HttpTester.parseResponse(servletTester.getResponses(request.generate()));
+  }
 
   @Before
   public void setup() throws Exception {
@@ -101,6 +124,10 @@ public class AssetServletTest {
     servletTester.addServlet(NoCharsetAssetServlet.class, NOCHARSET_SERVLET + '*');
     servletTester.addServlet(RootAssetServlet.class, ROOT_SERVLET + '*');
     servletTester.addServlet(MimeMappingsServlet.class, MIME_SERVLET + '*');
+
+    ServletHolder servlet = new ServletHolder(new MultipleMappingsServlet());
+    servletTester.addServlet(servlet, MM_ASSET_SERVLET + '*');
+    servletTester.addServlet(servlet, MM_JSON_SERVLET + '*');
     servletTester.start();
 
     servletTester.getContext().getMimeTypes().addMimeMapping("mp4", "video/mp4");
@@ -118,8 +145,7 @@ public class AssetServletTest {
 
   @Test
   public void servesFilesMappedToRoot() throws Exception {
-    request.setURI(ROOT_SERVLET + "assets/example.txt");
-    response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
+    response = makeRequest(ROOT_SERVLET + "assets/example.txt");
     assertThat(response.getStatus())
             .isEqualTo(200);
     assertThat(response.getContent())
@@ -128,15 +154,13 @@ public class AssetServletTest {
 
   @Test
   public void servesCharset() throws Exception {
-    request.setURI(DUMMY_SERVLET + "example.txt");
-    response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
+    response = makeRequest(DUMMY_SERVLET + "example.txt");
     assertThat(response.getStatus())
             .isEqualTo(200);
     assertThat(MimeTypes.CACHE.get(response.get(HttpHeader.CONTENT_TYPE)))
             .isEqualTo(MimeTypes.Type.TEXT_PLAIN_UTF_8);
 
-    request.setURI(NOCHARSET_SERVLET + "example.txt");
-    response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
+    response = makeRequest(NOCHARSET_SERVLET + "example.txt");
     assertThat(response.getStatus())
             .isEqualTo(200);
     assertThat(response.get(HttpHeader.CONTENT_TYPE))
@@ -145,8 +169,7 @@ public class AssetServletTest {
 
   @Test
   public void servesFilesFromRootsWithSameName() throws Exception {
-    request.setURI(DUMMY_SERVLET + "example2.txt");
-    response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
+    response = makeRequest(DUMMY_SERVLET + "example2.txt");
     assertThat(response.getStatus())
             .isEqualTo(200);
     assertThat(response.getContent())
@@ -155,7 +178,7 @@ public class AssetServletTest {
 
   @Test
   public void servesFilesWithA200() throws Exception {
-    response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
+    response = makeRequest();
     assertThat(response.getStatus())
             .isEqualTo(200);
     assertThat(response.getContent())
@@ -164,19 +187,17 @@ public class AssetServletTest {
 
   @Test
   public void throws404IfTheAssetIsMissing() throws Exception {
-    request.setURI(DUMMY_SERVLET + "doesnotexist.txt");
-
-    response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
+    response = makeRequest(DUMMY_SERVLET + "doesnotexist.txt");
     assertThat(response.getStatus())
             .isEqualTo(404);
   }
 
   @Test
   public void consistentlyAssignsETags() throws Exception {
-    response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
+    response = makeRequest();
     final String firstEtag = response.get(HttpHeaders.ETAG);
 
-    response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
+    response = makeRequest();
     final String secondEtag = response.get(HttpHeaders.ETAG);
 
     assertThat(firstEtag)
@@ -186,11 +207,10 @@ public class AssetServletTest {
 
   @Test
   public void assignsDifferentETagsForDifferentFiles() throws Exception {
-    response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
+    response = makeRequest();
     final String firstEtag = response.get(HttpHeaders.ETAG);
 
-    request.setURI(DUMMY_SERVLET + "foo.bar");
-    response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
+    response = makeRequest(DUMMY_SERVLET + "foo.bar");
     final String secondEtag = response.get(HttpHeaders.ETAG);
 
     assertThat(firstEtag)
@@ -201,15 +221,15 @@ public class AssetServletTest {
 
   @Test
   public void supportsIfNoneMatchRequests() throws Exception {
-    response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
+    response = makeRequest();
     final String correctEtag = response.get(HttpHeaders.ETAG);
 
     request.setHeader(HttpHeaders.IF_NONE_MATCH, correctEtag);
-    response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
+    response = makeRequest();
     final int statusWithMatchingEtag = response.getStatus();
 
     request.setHeader(HttpHeaders.IF_NONE_MATCH, correctEtag + "FOO");
-    response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
+    response = makeRequest();
     final int statusWithNonMatchingEtag = response.getStatus();
 
     assertThat(statusWithMatchingEtag)
@@ -220,10 +240,10 @@ public class AssetServletTest {
 
   @Test
   public void consistentlyAssignsLastModifiedTimes() throws Exception {
-    response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
+    response = makeRequest();
     final long firstLastModifiedTime = response.getDateField(HttpHeaders.LAST_MODIFIED);
 
-    response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
+    response = makeRequest();
     final long secondLastModifiedTime = response.getDateField(HttpHeaders.LAST_MODIFIED);
 
     assertThat(firstLastModifiedTime)
@@ -232,25 +252,19 @@ public class AssetServletTest {
 
   @Test
   public void supportsByteRangeForMedia() throws Exception {
-    request.setURI(ROOT_SERVLET + "assets/foo.mp4");
-    response = HttpTester.parseResponse(servletTester.getResponses(request
-            .generate()));
+    response = makeRequest(ROOT_SERVLET + "assets/foo.mp4");
     assertThat(response.getStatus()).isEqualTo(200);
     assertThat(response.get(HttpHeaders.ACCEPT_RANGES)).isEqualTo("bytes");
 
-    request.setURI(ROOT_SERVLET + "assets/foo.m4a");
-    response = HttpTester.parseResponse(servletTester.getResponses(request
-            .generate()));
+    response = makeRequest(ROOT_SERVLET + "assets/foo.m4a");
     assertThat(response.getStatus()).isEqualTo(200);
     assertThat(response.get(HttpHeaders.ACCEPT_RANGES)).isEqualTo("bytes");
   }
 
   @Test
   public void supportsFullByteRange() throws Exception {
-    request.setURI(ROOT_SERVLET + "assets/example.txt");
     request.setHeader(HttpHeaders.RANGE, "bytes=0-");
-    response = HttpTester.parseResponse(servletTester.getResponses(request
-            .generate()));
+    response = makeRequest(ROOT_SERVLET + "assets/example.txt");
     assertThat(response.getStatus()).isEqualTo(206);
     assertThat(response.getContent()).isEqualTo("HELLO THERE");
     assertThat(response.get(HttpHeaders.ACCEPT_RANGES)).isEqualTo("bytes");
@@ -260,10 +274,8 @@ public class AssetServletTest {
 
   @Test
   public void supportsCentralByteRange() throws Exception {
-    request.setURI(ROOT_SERVLET + "assets/example.txt");
     request.setHeader(HttpHeaders.RANGE, "bytes=4-8");
-    response = HttpTester.parseResponse(servletTester.getResponses(request
-            .generate()));
+    response = makeRequest(ROOT_SERVLET + "assets/example.txt");
     assertThat(response.getStatus()).isEqualTo(206);
     assertThat(response.getContent()).isEqualTo("O THE");
     assertThat(response.get(HttpHeaders.ACCEPT_RANGES)).isEqualTo("bytes");
@@ -274,10 +286,8 @@ public class AssetServletTest {
 
   @Test
   public void supportsFinalByteRange() throws Exception {
-    request.setURI(ROOT_SERVLET + "assets/example.txt");
     request.setHeader(HttpHeaders.RANGE, "bytes=10-10");
-    response = HttpTester.parseResponse(servletTester.getResponses(request
-            .generate()));
+    response = makeRequest(ROOT_SERVLET + "assets/example.txt");
     assertThat(response.getStatus()).isEqualTo(206);
     assertThat(response.getContent()).isEqualTo("E");
     assertThat(response.get(HttpHeaders.ACCEPT_RANGES)).isEqualTo("bytes");
@@ -286,8 +296,7 @@ public class AssetServletTest {
     assertThat(response.get(HttpHeaders.CONTENT_LENGTH)).isEqualTo("1");
 
     request.setHeader(HttpHeaders.RANGE, "bytes=-1");
-    response = HttpTester.parseResponse(servletTester.getResponses(request
-            .generate()));
+    response = makeRequest();
     assertThat(response.getStatus()).isEqualTo(206);
     assertThat(response.getContent()).isEqualTo("E");
     assertThat(response.get(HttpHeaders.ACCEPT_RANGES)).isEqualTo("bytes");
@@ -298,34 +307,27 @@ public class AssetServletTest {
 
   @Test
   public void rejectsInvalidByteRanges() throws Exception {
-    request.setURI(ROOT_SERVLET + "assets/example.txt");
     request.setHeader(HttpHeaders.RANGE, "bytes=test");
-    response = HttpTester.parseResponse(servletTester.getResponses(request
-            .generate()));
+    response = makeRequest(ROOT_SERVLET + "assets/example.txt");
     assertThat(response.getStatus()).isEqualTo(416);
 
     request.setHeader(HttpHeaders.RANGE, "bytes=");
-    response = HttpTester.parseResponse(servletTester.getResponses(request
-            .generate()));
+    response = makeRequest();
     assertThat(response.getStatus()).isEqualTo(416);
 
     request.setHeader(HttpHeaders.RANGE, "bytes=1-infinity");
-    response = HttpTester.parseResponse(servletTester.getResponses(request
-            .generate()));
+    response = makeRequest();
     assertThat(response.getStatus()).isEqualTo(416);
 
     request.setHeader(HttpHeaders.RANGE, "test");
-    response = HttpTester.parseResponse(servletTester.getResponses(request
-            .generate()));
+    response = makeRequest();
     assertThat(response.getStatus()).isEqualTo(416);
   }
 
   @Test
   public void supportsMultipleByteRanges() throws Exception {
-    request.setURI(ROOT_SERVLET + "assets/example.txt");
     request.setHeader(HttpHeaders.RANGE, "bytes=0-0,-1");
-    response = HttpTester.parseResponse(servletTester.getResponses(request
-            .generate()));
+    response = makeRequest(ROOT_SERVLET + "assets/example.txt");
     assertThat(response.getStatus()).isEqualTo(206);
     assertThat(response.getContent()).isEqualTo("HE");
     assertThat(response.get(HttpHeaders.ACCEPT_RANGES)).isEqualTo("bytes");
@@ -334,8 +336,7 @@ public class AssetServletTest {
     assertThat(response.get(HttpHeaders.CONTENT_LENGTH)).isEqualTo("2");
 
     request.setHeader(HttpHeaders.RANGE, "bytes=5-6,7-10");
-    response = HttpTester.parseResponse(servletTester.getResponses(request
-            .generate()));
+    response = makeRequest();
     assertThat(response.getStatus()).isEqualTo(206);
     assertThat(response.getContent()).isEqualTo(" THERE");
     assertThat(response.get(HttpHeaders.ACCEPT_RANGES)).isEqualTo("bytes");
@@ -346,20 +347,17 @@ public class AssetServletTest {
 
   @Test
   public void supportsIfRangeMatchRequests() throws Exception {
-    response = HttpTester.parseResponse(servletTester.getResponses(request
-            .generate()));
+    response = makeRequest();
     final String correctEtag = response.get(HttpHeaders.ETAG);
 
     request.setHeader(HttpHeaders.RANGE, "bytes=10-10");
 
     request.setHeader(HttpHeaders.IF_RANGE, correctEtag);
-    response = HttpTester.parseResponse(servletTester.getResponses(request
-            .generate()));
+    response = makeRequest();
     final int statusWithMatchingEtag = response.getStatus();
 
     request.setHeader(HttpHeaders.IF_RANGE, correctEtag + "FOO");
-    response = HttpTester.parseResponse(servletTester.getResponses(request
-            .generate()));
+    response = makeRequest();
     final int statusWithNonMatchingEtag = response.getStatus();
 
     assertThat(statusWithMatchingEtag).isEqualTo(206);
@@ -368,19 +366,19 @@ public class AssetServletTest {
 
   @Test
   public void supportsIfModifiedSinceRequests() throws Exception {
-    response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
+    response = makeRequest();
     final long lastModifiedTime = response.getDateField(HttpHeaders.LAST_MODIFIED);
 
     request.putDateField(HttpHeaders.IF_MODIFIED_SINCE, lastModifiedTime);
-    response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
+    response = makeRequest();
     final int statusWithMatchingLastModifiedTime = response.getStatus();
 
     request.putDateField(HttpHeaders.IF_MODIFIED_SINCE, lastModifiedTime - 100);
-    response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
+    response = makeRequest();
     final int statusWithStaleLastModifiedTime = response.getStatus();
 
     request.putDateField(HttpHeaders.IF_MODIFIED_SINCE, lastModifiedTime + 100);
-    response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
+    response = makeRequest();
     final int statusWithRecentLastModifiedTime = response.getStatus();
 
     assertThat(statusWithMatchingLastModifiedTime)
@@ -393,7 +391,7 @@ public class AssetServletTest {
 
   @Test
   public void guessesMimeTypes() throws Exception {
-    response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
+    response = makeRequest();
     assertThat(response.getStatus())
             .isEqualTo(200);
     assertThat(MimeTypes.CACHE.get(response.get(HttpHeader.CONTENT_TYPE)))
@@ -402,8 +400,7 @@ public class AssetServletTest {
 
   @Test
   public void defaultsToHtml() throws Exception {
-    request.setURI(DUMMY_SERVLET + "foo.bar");
-    response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
+    response = makeRequest(DUMMY_SERVLET + "foo.bar");
     assertThat(response.getStatus())
             .isEqualTo(200);
     assertThat(MimeTypes.CACHE.get(response.get(HttpHeader.CONTENT_TYPE)))
@@ -413,24 +410,21 @@ public class AssetServletTest {
   @Test
   public void servesIndexFilesByDefault() throws Exception {
     // Root directory listing:
-    request.setURI(DUMMY_SERVLET);
-    response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
+    response = makeRequest(DUMMY_SERVLET);
     assertThat(response.getStatus())
             .isEqualTo(200);
     assertThat(response.getContent())
             .contains("/assets Index File");
 
     // Subdirectory listing:
-    request.setURI(DUMMY_SERVLET + "some_directory");
-    response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
+    response = makeRequest(DUMMY_SERVLET + "some_directory");
     assertThat(response.getStatus())
             .isEqualTo(200);
     assertThat(response.getContent())
             .contains("/assets/some_directory Index File");
 
     // Subdirectory listing with slash:
-    request.setURI(DUMMY_SERVLET + "some_directory/");
-    response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
+    response = makeRequest(DUMMY_SERVLET + "some_directory/");
     assertThat(response.getStatus())
             .isEqualTo(200);
     assertThat(response.getContent())
@@ -440,55 +434,74 @@ public class AssetServletTest {
   @Test
   public void throwsA404IfNoIndexFileIsDefined() throws Exception {
     // Root directory listing:
-    request.setURI(NOINDEX_SERVLET + '/');
-    response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
+    response = makeRequest(NOINDEX_SERVLET + '/');
     assertThat(response.getStatus())
             .isEqualTo(404);
 
     // Subdirectory listing:
-    request.setURI(NOINDEX_SERVLET + "some_directory");
-    response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
+    response = makeRequest(NOINDEX_SERVLET + "some_directory");
     assertThat(response.getStatus())
             .isEqualTo(404);
 
     // Subdirectory listing with slash:
-    request.setURI(NOINDEX_SERVLET + "some_directory/");
-    response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
+    response = makeRequest(NOINDEX_SERVLET + "some_directory/");
     assertThat(response.getStatus())
             .isEqualTo(404);
   }
 
   @Test
   public void doesNotAllowOverridingUrls() throws Exception {
-    request.setURI(DUMMY_SERVLET + "file:/etc/passwd");
-    response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
+    response = makeRequest(DUMMY_SERVLET + "file:/etc/passwd");
     assertThat(response.getStatus())
             .isEqualTo(404);
   }
 
   @Test
   public void doesNotAllowOverridingPaths() throws Exception {
-    request.setURI(DUMMY_SERVLET + "/etc/passwd");
-    response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
+    response = makeRequest(DUMMY_SERVLET + "/etc/passwd");
     assertThat(response.getStatus())
             .isEqualTo(404);
   }
 
   @Test
   public void allowsEncodedAssetNames() throws Exception {
-    request.setURI(DUMMY_SERVLET + "encoded%20example.txt");
-    response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
+    response = makeRequest(DUMMY_SERVLET + "encoded%20example.txt");
     assertThat(response.getStatus())
             .isEqualTo(200);
   }
 
   @Test
   public void addMimeMappings() throws Exception {
-    request.setURI(MIME_SERVLET + "foo.bar");
-    response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
+    response = makeRequest(MIME_SERVLET + "foo.bar");
     assertThat(response.getStatus())
             .isEqualTo(200);
     assertThat(response.getStringField(HttpHeader.CONTENT_TYPE))
             .isEqualTo("application/bar");
+  }
+
+  @Test
+  public void servesFromMultipleMappings() throws Exception {
+    response = makeRequest(MM_ASSET_SERVLET + "/example.txt");
+    assertThat(response.getStatus())
+            .isEqualTo(200);
+    assertThat(response.getContent())
+            .isEqualTo("HELLO THERE");
+
+    response = makeRequest(MM_JSON_SERVLET + "/example.txt");
+    assertThat(response.getStatus())
+            .isEqualTo(200);
+    assertThat(response.getContent())
+            .isEqualTo("HELLO JSON");
+  }
+
+  @Test
+  public void noPollutionAcrossMultipleMappings() throws Exception {
+    response = makeRequest(MM_ASSET_SERVLET + "/json%20only.txt");
+    assertThat(response.getStatus())
+            .isEqualTo(404);
+
+    response = makeRequest(MM_JSON_SERVLET + "/json%20only.txt");
+    assertThat(response.getStatus())
+            .isEqualTo(200);
   }
 }

--- a/src/test/java/io/dropwizard/bundles/assets/AssetServletTest.java
+++ b/src/test/java/io/dropwizard/bundles/assets/AssetServletTest.java
@@ -34,13 +34,20 @@ public class AssetServletTest {
   private static final String RESOURCE_PATH = "/assets";
 
   // ServletTester expects to be able to instantiate the servlet with zero arguments
+  private static Iterable<Map.Entry<String, String>> resourceMapping(String resourcePath,
+                                                                     String uriPath) {
+    return ImmutableMap.<String, String>builder()
+            .put(resourcePath, uriPath)
+            .build()
+            .entrySet();
+  }
 
   public static class DummyAssetServlet extends AssetServlet {
     private static final long serialVersionUID = -1L;
 
     public DummyAssetServlet() {
-      super(RESOURCE_PATH, DUMMY_SERVLET, "index.htm", DEFAULT_CHARSET, DEFAULT_CACHE_SPEC,
-              EMPTY_OVERRIDES, EMPTY_MIMETYPES);
+      super(resourceMapping(RESOURCE_PATH, DUMMY_SERVLET), "index.htm", DEFAULT_CHARSET,
+              DEFAULT_CACHE_SPEC, EMPTY_OVERRIDES, EMPTY_MIMETYPES);
     }
   }
 
@@ -48,8 +55,8 @@ public class AssetServletTest {
     private static final long serialVersionUID = -1L;
 
     public NoIndexAssetServlet() {
-      super(RESOURCE_PATH, DUMMY_SERVLET, null, DEFAULT_CHARSET, DEFAULT_CACHE_SPEC,
-              EMPTY_OVERRIDES, EMPTY_MIMETYPES);
+      super(resourceMapping(RESOURCE_PATH, DUMMY_SERVLET), null, DEFAULT_CHARSET,
+              DEFAULT_CACHE_SPEC, EMPTY_OVERRIDES, EMPTY_MIMETYPES);
     }
   }
 
@@ -57,8 +64,8 @@ public class AssetServletTest {
     private static final long serialVersionUID = 1L;
 
     public RootAssetServlet() {
-      super("/", ROOT_SERVLET, null, DEFAULT_CHARSET, DEFAULT_CACHE_SPEC, EMPTY_OVERRIDES,
-              EMPTY_MIMETYPES);
+      super(resourceMapping("/", ROOT_SERVLET), null, DEFAULT_CHARSET, DEFAULT_CACHE_SPEC,
+              EMPTY_OVERRIDES, EMPTY_MIMETYPES);
     }
   }
 
@@ -66,15 +73,15 @@ public class AssetServletTest {
     private static final long serialVersionUID = 1L;
 
     public NoCharsetAssetServlet() {
-      super(RESOURCE_PATH, NOCHARSET_SERVLET, null, DEFAULT_CHARSET, DEFAULT_CACHE_SPEC,
-              EMPTY_OVERRIDES, EMPTY_MIMETYPES);
+      super(resourceMapping(RESOURCE_PATH, NOCHARSET_SERVLET), null, DEFAULT_CHARSET,
+              DEFAULT_CACHE_SPEC, EMPTY_OVERRIDES, EMPTY_MIMETYPES);
       setDefaultCharset(null);
     }
   }
 
   public static class MimeMappingsServlet extends AssetServlet {
     public MimeMappingsServlet() {
-      super(RESOURCE_PATH, MIME_SERVLET, null, DEFAULT_CHARSET, DEFAULT_CACHE_SPEC,
+      super(resourceMapping(RESOURCE_PATH, MIME_SERVLET), null, DEFAULT_CHARSET, DEFAULT_CACHE_SPEC,
               EMPTY_OVERRIDES, EMPTY_MIMETYPES);
       setDefaultCharset(null);
       Map<String, String> mimeMappings = new HashMap<String, String>();

--- a/src/test/java/io/dropwizard/bundles/assets/AssetsBundleTest.java
+++ b/src/test/java/io/dropwizard/bundles/assets/AssetsBundleTest.java
@@ -22,7 +22,6 @@ public class AssetsBundleTest {
   private final ServletEnvironment servletEnvironment = mock(ServletEnvironment.class);
   private final Environment environment = mock(Environment.class);
 
-  private AssetServlet servlet;
   private String servletPath;
 
   @Before
@@ -36,15 +35,6 @@ public class AssetsBundleTest {
 
     assertThat(servletPath)
             .isEqualTo("/assets/*");
-
-    assertThat(servlet.getIndexFile())
-            .isEqualTo("index.htm");
-
-    assertThat(servlet.getResourceUrl())
-            .isEqualTo(normalize("assets"));
-
-    assertThat(servlet.getUriPath())
-            .isEqualTo("/assets");
   }
 
   @Test
@@ -53,15 +43,6 @@ public class AssetsBundleTest {
 
     assertThat(servletPath)
             .isEqualTo("/json/*");
-
-    assertThat(servlet.getIndexFile())
-            .isEqualTo("index.htm");
-
-    assertThat(servlet.getResourceUrl())
-            .isEqualTo(normalize("json"));
-
-    assertThat(servlet.getUriPath())
-            .isEqualTo("/json");
   }
 
   @Test
@@ -70,15 +51,6 @@ public class AssetsBundleTest {
 
     assertThat(servletPath)
             .isEqualTo("/what/*");
-
-    assertThat(servlet.getIndexFile())
-            .isEqualTo("index.htm");
-
-    assertThat(servlet.getResourceUrl())
-            .isEqualTo(normalize("json"));
-
-    assertThat(servlet.getUriPath())
-            .isEqualTo("/what");
   }
 
   @Test
@@ -89,28 +61,10 @@ public class AssetsBundleTest {
     assertThat(servletPath)
             .isEqualTo("/what/new/*");
 
-    assertThat(servlet.getIndexFile())
-            .isEqualTo("index.txt");
-
-    assertThat(servlet.getResourceUrl())
-            .isEqualTo(normalize("json"));
-
-    assertThat(servlet.getUriPath())
-            .isEqualTo("/what/new");
-
     runBundle(new ConfiguredAssetsBundle("/json", "/what/old", "index.txt", "customAsset2"),
             "customAsset2");
     assertThat(servletPath)
             .isEqualTo("/what/old/*");
-
-    assertThat(servlet.getIndexFile())
-            .isEqualTo("index.txt");
-
-    assertThat(servlet.getResourceUrl())
-            .isEqualTo(normalize("json"));
-
-    assertThat(servlet.getUriPath())
-            .isEqualTo("/what/old");
   }
 
   @Test
@@ -119,15 +73,6 @@ public class AssetsBundleTest {
 
     assertThat(servletPath)
             .isEqualTo("/what/*");
-
-    assertThat(servlet.getIndexFile())
-            .isEqualTo("index.txt");
-
-    assertThat(servlet.getResourceUrl())
-            .isEqualTo(normalize("json"));
-
-    assertThat(servlet.getUriPath())
-            .isEqualTo("/what");
   }
 
   private URL normalize(String path) {
@@ -157,7 +102,6 @@ public class AssetsBundleTest {
     verify(servletEnvironment).addServlet(eq(assetName), servletCaptor.capture());
     verify(registration).addMapping(pathCaptor.capture());
 
-    this.servlet = servletCaptor.getValue();
     this.servletPath = pathCaptor.getValue();
   }
 }

--- a/src/test/resources/json/example.txt
+++ b/src/test/resources/json/example.txt
@@ -1,0 +1,1 @@
+HELLO JSON


### PR DESCRIPTION
The dropwizard world now allows you to install multiple `AssetsBundle`s when they want to have two different resource locations mapped to different URIs. This makes far less sense with the ConfigurableAssetsBundle as you can't actually control the cache spec individually if you install multiple bundles concurrently.

This enables that functionality in a safe and consistent manner.

Related:
bazaarvoice/dropwizard-configurable-assets-bundle#20
