### PR TITLE
Pr2

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,32 @@ assets:
     /dashboard/images: /some/different/absolute/path/with/images
 ```
 
+Instead of defining the resource path to uri path mappings in java code, they also can be specified in the configuration file.
+```java
+public class SampleService extends Application<SampleConfiguration> {
+    ...
+
+    @Override
+    public void initialize(Bootstrap<SampleConfiguration> bootstrap) {
+        bootstrap.addBundle(new ConfiguredAssetsBundle());
+    }
+
+    @Override
+    public void run(SampleConfiguration configuration, Environment environment) {
+        ...
+    }
+}
+```
+
+```yml
+assets:
+  mappings:
+    /assets: /dashboard
+  overrides:
+    /dashboard/assets: /some/absolute/path/with/assets/
+    /dashboard/images: /some/different/absolute/path/with/images
+```
+
 ## Add Mime Types
 
 Dropwizard 0.8 allows you to add new mimetypes directly to the application context.
@@ -103,6 +129,7 @@ assets:
 
 You can map different folders to multiple top-level directories if you wish.
 
+Either in java code
 ```java
 public class SampleService extends Application<SampleConfiguration> {
     ...
@@ -117,4 +144,14 @@ public class SampleService extends Application<SampleConfiguration> {
         ));
     }
 }
+```
+
+or either in the configuration file
+```yml
+assets:
+  mappings:
+    /assets: /dashboard
+    /data: /static-data
+  overrides:
+    ...
 ```

--- a/src/main/java/io/dropwizard/bundles/assets/AssetsConfiguration.java
+++ b/src/main/java/io/dropwizard/bundles/assets/AssetsConfiguration.java
@@ -1,18 +1,29 @@
 package io.dropwizard.bundles.assets;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
+
 import java.util.Map;
 import javax.validation.constraints.NotNull;
 
 public class AssetsConfiguration {
+  public static final String SLASH = "/";
+  @JsonProperty
+  private Map<String, String> mappings = Maps.newHashMap();
+
+  protected Map<String, String> mappings() {
+    return mappings;
+  }
+
   /**
    * Initialize cacheSpec to null so that whatever may be specified by code is able to be
    * by configuration. If null the default cache spec of "maximumSize=100" will be used.
    *
    * @see ConfiguredAssetsBundle#DEFAULT_CACHE_SPEC
    */
+
   @JsonProperty
   private String cacheSpec = null;
 
@@ -23,6 +34,29 @@ public class AssetsConfiguration {
   @NotNull
   @JsonProperty
   private Map<String, String> mimeTypes = Maps.newHashMap();
+
+  private Map<String, String> resourcePathToUriMappings;
+  /**
+   * A series of mappings from resource paths (in the classpath)
+   * to the uri path that hosts the resource
+   * @return The resourcePathToUriMappings.
+   */
+  public Map<String, String> getResourcePathToUriMappings() {
+    if (resourcePathToUriMappings == null) {
+      ImmutableMap.Builder<String, String> mapBuilder = ImmutableMap.<String, String>builder();
+      // Ensure that resourcePath and uri ends with a '/'
+      for (Map.Entry<String, String> mapping : mappings().entrySet()) {
+        mapBuilder
+            .put(ensureEndsWithSlash(mapping.getKey()), ensureEndsWithSlash(mapping.getValue()));
+      }
+      resourcePathToUriMappings = mapBuilder.build();
+    }
+    return resourcePathToUriMappings;
+  }
+
+  private String ensureEndsWithSlash(String value) {
+    return value != null ? (value.endsWith(SLASH) ? value : value + SLASH) : SLASH;
+  }
 
   /**
    * The caching specification for how to memoize assets.

--- a/src/main/java/io/dropwizard/bundles/assets/URLUtil.java
+++ b/src/main/java/io/dropwizard/bundles/assets/URLUtil.java
@@ -1,0 +1,7 @@
+package io.dropwizard.bundles.assets;
+
+/**
+ * Created by roeveko on 04/06/2015.
+ */
+public class URLUtil {
+}

--- a/src/main/java/io/dropwizard/bundles/assets/URLUtil.java
+++ b/src/main/java/io/dropwizard/bundles/assets/URLUtil.java
@@ -1,7 +1,0 @@
-package io.dropwizard.bundles.assets;
-
-/**
- * Created by roeveko on 04/06/2015.
- */
-public class URLUtil {
-}

--- a/src/test/java/io/dropwizard/bundles/assets/AssetsBundleTest.java
+++ b/src/test/java/io/dropwizard/bundles/assets/AssetsBundleTest.java
@@ -2,11 +2,8 @@ package io.dropwizard.bundles.assets;
 
 import com.google.common.cache.CacheBuilderSpec;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.io.Resources;
 import io.dropwizard.jetty.setup.ServletEnvironment;
-import io.dropwizard.servlets.assets.ResourceURL;
 import io.dropwizard.setup.Environment;
-import java.net.URL;
 import java.util.List;
 import javax.servlet.ServletRegistration;
 import org.junit.Before;

--- a/src/test/java/io/dropwizard/bundles/assets/AssetsConfigurationTest.java
+++ b/src/test/java/io/dropwizard/bundles/assets/AssetsConfigurationTest.java
@@ -1,0 +1,43 @@
+package io.dropwizard.bundles.assets;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.Assert;
+
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class AssetsConfigurationTest {
+  private AssetsConfiguration config;
+
+  private final static String A_RESOURCE_PATH = "/a/resource/path";
+  private final static String AN_URI = "/an/uri";
+
+  @Before
+  public void setupConfig() throws Exception {
+    final Map<String, String> mappings = new HashMap<>();
+    mappings.put(A_RESOURCE_PATH, AN_URI);
+    config = new AssetsConfiguration() {
+      @Override
+      protected Map<String, String> mappings() {
+        return mappings;
+      }
+    };
+  }
+
+  @After
+  public void clearConfig() throws Exception {
+    config = null;
+  }
+
+  @Test
+  public void keysAndValuesInTheResourcePathUriMappinsAlwaysEndWithSlash() {
+    Map<String, String> actualMappings = config.getResourcePathToUriMappings();
+    Assert.assertNotNull(actualMappings);
+    Assert.assertEquals(1, actualMappings.size());
+    Assert.assertTrue(actualMappings.containsKey(A_RESOURCE_PATH + "/"));
+    Assert.assertEquals(AN_URI + "/", actualMappings.get(A_RESOURCE_PATH + "/"));
+  }
+}


### PR DESCRIPTION
Added new feature: The resource path to uri mappings can be overridden in the yml configuration file

Motivation:
Application path and admin path can be specified in the yml configuration file. Inline with this feature it makes sense to provide the same functionality for the asset URIs.
