### PR TITLE
Fixes issue #13, which now allows you to start up without a configuration.

### DIFF
--- a/src/main/java/io/dropwizard/bundles/assets/AssetsConfiguration.java
+++ b/src/main/java/io/dropwizard/bundles/assets/AssetsConfiguration.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 
+import java.util.Collections;
 import java.util.Map;
 import javax.validation.constraints.NotNull;
 
@@ -67,11 +68,11 @@ public class AssetsConfiguration {
     return cacheSpec;
   }
 
-  public Iterable<Map.Entry<String, String>> getOverrides() {
-    return Iterables.unmodifiableIterable(overrides.entrySet());
+  public Map<String, String> getOverrides() {
+    return Collections.unmodifiableMap(overrides);
   }
 
-  public Iterable<Map.Entry<String, String>> getMimeTypes() {
-    return Iterables.unmodifiableIterable(mimeTypes.entrySet());
+  public Map<String, String> getMimeTypes() {
+    return Collections.unmodifiableMap(mimeTypes);
   }
 }

--- a/src/main/java/io/dropwizard/bundles/assets/ConfiguredAssetsBundle.java
+++ b/src/main/java/io/dropwizard/bundles/assets/ConfiguredAssetsBundle.java
@@ -8,7 +8,6 @@ import io.dropwizard.ConfiguredBundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 
-import java.util.Iterator;
 import java.util.Map;
 
 import org.slf4j.Logger;
@@ -314,8 +313,8 @@ public class ConfiguredAssetsBundle implements ConfiguredBundle<AssetsBundleConf
         ? CacheBuilderSpec.parse(config.getCacheSpec())
         : cacheBuilderSpec;
 
-    Iterable<Map.Entry<String, String>> overrides = config.getOverrides();
-    Iterable<Map.Entry<String, String>> mimeTypes = config.getMimeTypes();
+    Iterable<Map.Entry<String, String>> overrides = config.getOverrides().entrySet();
+    Iterable<Map.Entry<String, String>> mimeTypes = config.getMimeTypes().entrySet();
 
     Iterable<Map.Entry<String, String>> servletResourcePathToUriMappings;
 


### PR DESCRIPTION
Apparently, when you don't specify a configuration file dropwizard first serializes your configuration object into JSON, and then promptly deserializes it. The typing between the getter and the field was inconsistent causing the offending error.
