### PR TITLE
Remove CacheBuilder 'ignoring weigher' warning.

### DIFF
--- a/src/main/java/io/dropwizard/bundles/assets/AssetServlet.java
+++ b/src/main/java/io/dropwizard/bundles/assets/AssetServlet.java
@@ -79,7 +79,14 @@ public class AssetServlet extends HttpServlet {
                       Iterable<Map.Entry<String, String>> mimeTypes) {
     this.defaultCharset = defaultCharset;
     AssetLoader loader = new AssetLoader(resourcePathToUriPathMapping, indexFile, overrides);
-    this.cache = CacheBuilder.from(spec).weigher(new AssetSizeWeigher()).build(loader);
+
+    CacheBuilder<Object, Object> cacheBuilder = CacheBuilder.from(spec);
+    // Don't add the weigher if we are using maximumSize instead of maximumWeight.
+    if (spec.toParsableString().contains("maximumWeight=")) {
+      cacheBuilder.weigher(new AssetSizeWeigher());
+    }
+    this.cache = cacheBuilder.build(loader);
+
     this.cacheSpec = spec;
     this.mimeTypes = new MimeTypes();
     this.setMimeTypes(mimeTypes);


### PR DESCRIPTION
CacheBuilder warns if a weigher was specified and the spec does not supply a maximumWeight. This change simply does not add the weigher unless maximumWeight is provided, thus getting rid of the warning.
