### PR TITLE
Add builder to AssetConfiguration

### DIFF
--- a/src/main/java/io/dropwizard/bundles/assets/AssetServlet.java
+++ b/src/main/java/io/dropwizard/bundles/assets/AssetServlet.java
@@ -19,7 +19,6 @@ import io.dropwizard.servlets.assets.ByteRange;
 import io.dropwizard.servlets.assets.ResourceURL;
 import java.io.File;
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.util.List;

--- a/src/main/java/io/dropwizard/bundles/assets/AssetsConfiguration.java
+++ b/src/main/java/io/dropwizard/bundles/assets/AssetsConfiguration.java
@@ -1,22 +1,18 @@
 package io.dropwizard.bundles.assets;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
-
 import java.util.Collections;
 import java.util.Map;
 import javax.validation.constraints.NotNull;
 
 public class AssetsConfiguration {
   public static final String SLASH = "/";
+
   @JsonProperty
   private Map<String, String> mappings = Maps.newHashMap();
-
-  protected Map<String, String> mappings() {
-    return mappings;
-  }
 
   /**
    * Initialize cacheSpec to null so that whatever may be specified by code is able to be
@@ -40,6 +36,18 @@ public class AssetsConfiguration {
   private String cacheControlHeader = null;
 
   private Map<String, String> resourcePathToUriMappings;
+
+  private AssetsConfiguration(
+      String cacheSpec,
+      Map<String, String> mappings,
+      Map<String, String> mimeTypes,
+      Map<String, String> overrides) {
+    this.cacheSpec = cacheSpec;
+    this.mappings = Collections.unmodifiableMap(mappings);
+    this.mimeTypes = Collections.unmodifiableMap(mimeTypes);
+    this.overrides = Collections.unmodifiableMap(overrides);
+  }
+
   /**
    * A series of mappings from resource paths (in the classpath)
    * to the uri path that hosts the resource
@@ -62,6 +70,10 @@ public class AssetsConfiguration {
     return value != null ? (value.endsWith(SLASH) ? value : value + SLASH) : SLASH;
   }
 
+  protected Map<String, String> mappings() {
+    return mappings;
+  }
+
   /**
    * The caching specification for how to memoize assets.
    *
@@ -81,6 +93,44 @@ public class AssetsConfiguration {
 
   public String getCacheControlHeader() {
     return cacheControlHeader;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+
+    private String cacheSpec;
+    private Map<String, String> mappings = Maps.newHashMap();
+    private Map<String, String> mimeTypes = Maps.newHashMap();
+    private Map<String, String> overrides = Maps.newHashMap();
+
+    private Builder() {}
+
+    public Builder cacheSpec(String cacheSpec) {
+      this.cacheSpec = cacheSpec;
+      return this;
+    }
+
+    public Builder mappings(Map<String, String> mappings) {
+      this.mappings = Preconditions.checkNotNull(mappings);
+      return this;
+    }
+
+    public Builder mimeTypes(Map<String, String> mimeTypes) {
+      this.mimeTypes = Preconditions.checkNotNull(mimeTypes);
+      return this;
+    }
+
+    public Builder overrides(Map<String, String> overrides) {
+      this.overrides = Preconditions.checkNotNull(overrides);
+      return this;
+    }
+
+    public AssetsConfiguration build() {
+      return new AssetsConfiguration(cacheSpec, mappings, mimeTypes, overrides);
+    }
   }
 
 }

--- a/src/test/java/io/dropwizard/bundles/assets/AssetsBundleTest.java
+++ b/src/test/java/io/dropwizard/bundles/assets/AssetsBundleTest.java
@@ -26,7 +26,7 @@ public class AssetsBundleTest {
   private final AssetsBundleConfiguration defaultConfiguration = new AssetsBundleConfiguration() {
     @Override
     public AssetsConfiguration getAssetsConfiguration() {
-      return new AssetsConfiguration();
+      return AssetsConfiguration.builder().build();
     }
   };
 
@@ -111,12 +111,7 @@ public class AssetsBundleTest {
     AssetsBundleConfiguration config = new AssetsBundleConfiguration() {
       @Override
       public AssetsConfiguration getAssetsConfiguration() {
-        return new AssetsConfiguration() {
-          @Override
-          public String getCacheSpec() {
-            return cacheSpec;
-          }
-        };
+        return AssetsConfiguration.builder().cacheSpec(cacheSpec).build();
       }
     };
 

--- a/src/test/java/io/dropwizard/bundles/assets/AssetsConfigurationTest.java
+++ b/src/test/java/io/dropwizard/bundles/assets/AssetsConfigurationTest.java
@@ -19,12 +19,7 @@ public class AssetsConfigurationTest {
   public void setupConfig() throws Exception {
     final Map<String, String> mappings = new HashMap<>();
     mappings.put(A_RESOURCE_PATH, AN_URI);
-    config = new AssetsConfiguration() {
-      @Override
-      protected Map<String, String> mappings() {
-        return mappings;
-      }
-    };
+    config = AssetsConfiguration.builder().mappings(mappings).build();
   }
 
   @After


### PR DESCRIPTION
This allows consuming apps to specify AssetConfiguration in code if the apps want to serve assets from disk while still allows overrides from the yaml file during development
