### PR TITLE
Updated to Dropwizard 1.0.0-rc2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: java
+jdk:
+    - oraclejdk8

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.dropwizard-bundles</groupId>
     <artifactId>dropwizard-configurable-assets-bundle</artifactId>
-    <version>0.9.2-3-SNAPSHOT</version>
+    <version>1.0.0-rc2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <parent>
@@ -46,9 +46,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <dropwizard.version>0.9.2</dropwizard.version>
-        <guava.version>18.0</guava.version>
-        <jetty.version>9.2.13.v20150730</jetty.version>
+        <dropwizard.version>1.0.0-rc2</dropwizard.version>
+        <guava.version>19.0</guava.version>
+        <jetty.version>9.3.8.v20160314</jetty.version>
     </properties>
 
     <dependencies>
@@ -73,6 +73,22 @@
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
             <version>${jetty.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlet</artifactId>
+            <version>${jetty.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-http</artifactId>
+            <version>${jetty.version}</version>
+            <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Dropwizard rc2 released; just keeping up with it.
Use OpenJDK8 because it is required for Jetty 9.3
