### PR TITLE
Fixed possible typo in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ public class SampleConfiguration extends Configuration implements AssetsBundleCo
   @Valid
   @NotNull
   @JsonProperty
-  private final AssetsConfiguration assets = new AssetsConfiguration();
+  private final AssetsConfiguration assets = AssetsConfiguration.builder().build();
 
   @Override
   public AssetsConfiguration getAssetsConfiguration() {


### PR DESCRIPTION
Thanks alot for this library - doing UI development without it would be a complete pain in the ass. 

When running through `readme.md`, I found I couldn't call `new AssetsConfiguration();` because it's protected. Looking through the tests, it seems like the builder is used in preference to that. If that's the correct usage, this pull request will fix the typo.

Thanks again